### PR TITLE
Energy calib

### DIFF
--- a/profile_collection/startup/20-scalers.py
+++ b/profile_collection/startup/20-scalers.py
@@ -13,5 +13,6 @@ for ch_name in em.channels.signal_names:
 sc = EpicsScaler('XF:28IDC-ES:1{Det:SC2}', name='sc')
 sc.channels.read_attrs = ['chan%d' % i for i in [1, 2]]
 for ch_name in sc.channels.signal_names:
+    # Rename sc_channels_chan1 to sc_chan1
     ch = getattr(sc.channels, ch_name)
     ch.name = ch.name.replace('_channels_', '_')

--- a/profile_collection/startup/42-energy-calib.py
+++ b/profile_collection/startup/42-energy-calib.py
@@ -93,6 +93,8 @@ class ComputeWavelength(CollectThenCompute):
     """
     CONVERSION_FACTOR = 12.3984  # keV-Angstroms
     def __init__(self, x_name, y_name, d_spacings, ns=None):
+        self._descriptors = []
+        self._events = []
         self.x_name = x_name
         self.y_name = y_name
         self.d_spacings = d_spacings
@@ -117,6 +119,8 @@ class ComputeWavelength(CollectThenCompute):
             x.append(event['data'][self.x_name])
             y.append(event['data'][self.y_name])
 
+        x = np.array(x)
+        y = np.array(y)
         self.wavelength, self.wavelength_std = get_wavelength_from_std_tth(x, y, self.d_spacings, self.ns)
         print('wavelength', self.wavelength, '+-', self.wavelength_std)
         print('energy', self.energy)

--- a/profile_collection/startup/42-energy-calib.py
+++ b/profile_collection/startup/42-energy-calib.py
@@ -140,7 +140,7 @@ if __name__ == '__main__':
         for dx in b:
             x = a[:, 0]
             x = np.hstack((np.zeros(1), x))
-            x = np.hstack((-x[::-1], x))
+            x = np.hstack((-x[::-2], x))
             y = a[:, 1]
             y = np.hstack((np.zeros(1), y))
             y = np.hstack((y[::-1], y))

--- a/profile_collection/startup/80-areadetector.py
+++ b/profile_collection/startup/80-areadetector.py
@@ -238,4 +238,4 @@ pe1c.tiff.read_attrs = []  # just the image
 pe1c.stats1.read_attrs = ['total']
 
 # some defaults, as an example of how to use this
-pe1.configure(dict(images_per_set=6, number_of_sets=10))
+# pe1.configure(dict(images_per_set=6, number_of_sets=10))

--- a/profile_collection/startup/90-plans.py
+++ b/profile_collection/startup/90-plans.py
@@ -1,0 +1,29 @@
+import os
+import numpy as np
+from bluesky.plans import scan, subs_wrapper, abs_set, pchain, reset_positions_wrapper
+from bluesky.callbacks import LiveTable, LivePlot
+
+
+d_spacings = np.loadtxt(os.path.join('/nfs/xf28id1/ipython_ophyd/profile_collection/startup/../../data/LaB6_d.txt'))
+
+
+def Ecal(start=-4, stop=-1.5, step_size=0.01):
+    """
+    Energy calibration scan
+
+    Example
+    -------
+
+    Execute an energy calibration scan with default steps.
+    >>> RE(Ecal())
+    """
+    plan = scan([sc], tth_cal, start, stop, (stop - start)/step_size)
+    # plan = pchain(abs_set(x_cal, 0), abs_set(y_cal, 0), plan) 
+    # plan = reset_positions_wrapper(plan)
+
+    # Send data documnets to cw, LiveTable, LivePlot.
+    cw = ComputeWavelength('tth_cal', 'sc_chan1', d_spacings)
+    subs = [cw, LiveTable(['tth_cal', 'sc_chan1']), LivePlot('sc_chan1', 'tth_cal')]
+    plan = subs_wrapper(plan, subs)
+
+    yield from plan


### PR DESCRIPTION
With these fixes, the ComputeWavelength callback works. It prints a wavelength and energy after a scan completes. It has been incorporated in a custom plan, `Ecal`, also in this PR.

It can also be applied to saved data, using `db.process(db[...], ComputeWavelength(...))`. Here are some runs for future testing. None of the data was great, but at least it's something to test on now.

A short scan that saw only two peaks: 8a1950
Two long scans with peaks that don't look so nice: 3af79c and 3777f4