### PR TITLE
Mnt q3 updates

### DIFF
--- a/profile_collection/startup/01-olog-integration.py
+++ b/profile_collection/startup/01-olog-integration.py
@@ -1,6 +1,9 @@
+from bluesky.callbacks.olog import logbook_cb_factory
 from functools import partial
 from pyOlog import SimpleOlogClient
-from bluesky.callbacks.olog import logbook_cb_factory
+import queue
+import threading
+from warnings import warn
 
 # Set up the logbook. This configures bluesky's summaries of
 # data acquisition (scan type, ID, etc.).
@@ -10,5 +13,32 @@ simple_olog_client = SimpleOlogClient()
 generic_logbook_func = simple_olog_client.log
 configured_logbook_func = partial(generic_logbook_func, logbooks=LOGBOOKS)
 
+# This is for ophyd.commands.get_logbook, which simply looks for
+# a variable called 'logbook' in the global IPython namespace.
+logbook = simple_olog_client
+
 cb = logbook_cb_factory(configured_logbook_func)
-RE.subscribe('start', cb)
+
+
+def submit_to_olog(queue, cb):
+    while True:
+        name, doc = queue.get()  # waits until document is available
+        try:
+            cb(name, doc)
+        except Exception as exc:
+            warn('This olog is giving errors. This will not be logged.'
+                 'Error:' + str(exc))
+
+olog_queue = queue.Queue(maxsize=100)
+olog_thread = threading.Thread(target=submit_to_olog, args=(olog_queue, cb), daemon=True)
+olog_thread.start()
+
+
+def send_to_olog_queue(name, doc):
+    try:
+        olog_queue.put((name, doc), block=False)
+    except queue.Full:
+        warn('The olog queue is full. This will not be logged.')
+
+
+RE.subscribe(send_to_olog_queue, 'start')

--- a/profile_collection/startup/80-areadetector.py
+++ b/profile_collection/startup/80-areadetector.py
@@ -128,12 +128,12 @@ class XPDPerkinElmer(PerkinElmerDetector):
              proc_name='proc',  # ditto
              read_attrs=[],
              root='/direct/XF28ID1/',
-             fs=db.fs)
+             reg=db.reg)
 
     # hdf5 = C(XPDHDF5Plugin, 'HDF1:',
     #          write_path_template='G:/pe1_data/%Y/%m/%d/',
     #          read_path_template='/direct/XF28ID1/pe1_data/%Y/%m/%d/',
-    #          root='/direct/XF28ID1/', fs=db.fs)
+    #          root='/direct/XF28ID1/', reg=db.reg)
 
     proc = C(ProcessPlugin, 'Proc1:')
 

--- a/profile_collection/startup/99-setup-gs.py
+++ b/profile_collection/startup/99-setup-gs.py
@@ -1,8 +1,0 @@
-# Configure bluesky default detectors with this:
-# These are the new "default detectors"
-gs.DETS = [em]
-gs.TABLE_COLS.append('em_chan21')
-gs.PLOT_Y = 'em_chan21'
-gs.TEMP_CONTROLLER = cs700
-gs.TH_MOTOR = th
-gs.TTH_MOTOR = tth

--- a/profile_collection/startup/99-subtracted-tiff-exporter.py
+++ b/profile_collection/startup/99-subtracted-tiff-exporter.py
@@ -9,8 +9,8 @@ class SubtractedTiffExporter(LiveTiffExporter):
         if 'dark_frame' not in doc:
             raise ValueError("No dark_frame was recorded.")
         uid = doc['dark_frame']
-        dark_header = db[uid]
-        self.dark_img, = get_images(db[uid], 'pe1_image')
+        h = db[uid]
+        self.dark_img, = h.get_data('pe1_image')
         super().start(doc)
 
     def event(self, doc):

--- a/profile_collection/startup/99-subtracted-tiff-exporter.py
+++ b/profile_collection/startup/99-subtracted-tiff-exporter.py
@@ -1,34 +1,4 @@
-from time import sleep
 from bluesky.callbacks.broker import LiveTiffExporter
-from databroker import process
-from bluesky import Msg
-from bluesky.plans import DeltaScanPlan, DeltaListScanPlan
-
-
-def take_dark():
-    print('closing shutter...')
-    shctl1.put(0)  # close shutter
-    sleep(2)
-    print('taking dark frame....')
-    uid, = RE(Count([pe1c]))
-    print('opening shutter...')
-    shctl1.put(1)
-    sleep(2)
-    return uid
-
-
-def run(motor, x, start, stop, num_steps, loops, *, exposure=1,  **metadata):
-    print('moving %s to initial position' % motor.name)
-    subs = [LiveTable(['pe1_stats1_total', motor.name]),
-            LivePlot('pe1_stats1_total', motor.name)]
-    motor.move(x)
-    pe1c.images_per_set.put(exposure // 0.1)
-    dark_uid = take_dark()
-    steps = loops * list(np.linspace(start, stop, num=num_steps, endpoint=True))
-    plan = DeltaListScanPlan([pe1c], motor, steps)
-    uid = RE(plan, subs, dark_frame=dark_uid, **metadata)
-    sleep(3)
-    process(db[uid], exporter)
 
 
 class SubtractedTiffExporter(LiveTiffExporter):

--- a/profile_collection/startup/99-subtracted-tiff-exporter.py
+++ b/profile_collection/startup/99-subtracted-tiff-exporter.py
@@ -4,8 +4,6 @@ from databroker import process
 from bluesky import Msg
 from bluesky.plans import DeltaScanPlan, DeltaListScanPlan
 
-RE = gs.RE  # an alias
-
 
 def take_dark():
     print('closing shutter...')

--- a/profile_collection/startup/99-subtracted-tiff-exporter.py
+++ b/profile_collection/startup/99-subtracted-tiff-exporter.py
@@ -19,5 +19,9 @@ class SubtractedTiffExporter(LiveTiffExporter):
         doc['data'][self.field] = subtracted_img
         super().event(doc)
 
-template = "/home/xf28id1/xpdUser/tiff_base/LaB6_EPICS/{start.sa_name}_{start.scan_id}_step{event.seq_num}.tif"
+
+# TODO this looks too hard-coded!
+template = ("/home/xf28id1/xpdUser/tiff_base/LaB6_EPICS/"
+            "{start.sa_name}_{start.scan_id}_step{event.seq_num}.tif")
+
 exporter = SubtractedTiffExporter('pe1_image', template)


### PR DESCRIPTION
attn @CJ-Wright 

```yaml
description: 'production XPD mongo'
metadatastore:
    module: 'databroker.headersource.mongo'
    class: 'MDS'
    config:
        host: 'xf28id-ca1.cs.nsls2.local'
        port: 27017
        database: 'datastore'
        timezone: 'US/Eastern'
assets:
    module: 'databroker.assets.mongo'
    class: 'Registry'
    config:
        host: 'xf28id-ca1.cs.nsls2.local'
        port: 27017
        database: 'filestore'

```

That file will have to go one of places listed in https://nsls-ii.github.io/databroker/configuration.html#search-path Eventually we will roll this out into `/etc/`, but have not gotten to that bit of dev-ops yet.

You should have a careful look at the changes to 00-startup.py as we changed the 'stock' subscriptions and preprocessor.  IIRC xpdacq has it's own RE?  SD + BEC + hints might greatly simplify some of your stuff.

Stuff I would like @CJ-Wright to take care of with XPD:

 - [ ] tuning what is in `BlueskyMagics.detectors` for `%ct`
 - [ ] tuning what is in `BlueskyMagics.positioners` for `%wa`
 - [ ] tuning hints on devices (this is really just setting (`obj.hints = {'fields': [...]}`)
 - [ ] turing what is in sd.detectors

You may have the version of bluesky with the 'returns a list instance' RE on monday so be aware of that.

Something went wrong and we do not have internal conda packages of bluesky or databroker (but ophyd worked :man_shrugging: ), will have those by Monday.